### PR TITLE
Fix FormatExceptions due to Enum.ToString not supporting precision

### DIFF
--- a/src/LibObjectFile/Elf/ElfPrinter.cs
+++ b/src/LibObjectFile/Elf/ElfPrinter.cs
@@ -365,7 +365,7 @@ namespace LibObjectFile.Elf
 
             if (builder.Length == 0)
             {
-                builder.Append($"Unknown note type: (0x{note.GetNoteType().Value:x8})");
+                builder.Append($"Unknown note type: (0x{(uint)note.GetNoteType().Value:x8})");
             }
 
             builder.Append("\t\t");

--- a/src/LibObjectFile/Elf/Sections/ElfNoteType.cs
+++ b/src/LibObjectFile/Elf/Sections/ElfNoteType.cs
@@ -28,7 +28,7 @@ namespace LibObjectFile.Elf
 
         public override string ToString()
         {
-            return ToStringInternal() ?? $"Unknown {nameof(ElfNoteTypeEx)} (0x{Value:X4})";
+            return ToStringInternal() ?? $"Unknown {nameof(ElfNoteTypeEx)} (0x{(uint)Value:X4})";
         }
 
         public bool Equals(ElfNoteTypeEx other)


### PR DESCRIPTION
cc @xoofx 