### PR TITLE
Fix SliceStream.Seek offset check

### DIFF
--- a/src/LibObjectFile/Utils/SliceStream.cs
+++ b/src/LibObjectFile/Utils/SliceStream.cs
@@ -91,7 +91,7 @@ namespace LibObjectFile.Utils
             }
 
             if (newPosition < 0) throw new ArgumentOutOfRangeException(nameof(offset), $"New resulting position {newPosition} is < 0");
-            if (newPosition > _length) throw new ArgumentOutOfRangeException(nameof(offset), $"New resulting position {newPosition} is >= Length {_length}");
+            if (newPosition > _length) throw new ArgumentOutOfRangeException(nameof(offset), $"New resulting position {newPosition} is > Length {_length}");
 
             // Check that we can seek on the origin stream
             _baseStream.Position = _basePosition + newPosition;


### PR DESCRIPTION
Suppose that SliceStream has zero length. At the creation `Position` will have value `0` and. The check in `Seek` method would prevent reassigning the `0` to `Position` property which should be perfectly valid.