### PR TITLE
Add support for encoding location lists

### DIFF
--- a/src/LibObjectFile.Tests/Dwarf/DwarfTests.cs
+++ b/src/LibObjectFile.Tests/Dwarf/DwarfTests.cs
@@ -459,6 +459,31 @@ namespace LibObjectFile.Tests.Dwarf
             };
             rootDIE.AddChild(subProgram);
 
+            var locationList = new DwarfLocationList();
+            var regExpression = new DwarfExpression();
+            regExpression.AddOperation(new DwarfOperation { Kind = DwarfOperationKindEx.Reg0 });            
+            var regExpression2 = new DwarfExpression();
+            regExpression2.AddOperation(new DwarfOperation { Kind = DwarfOperationKindEx.Reg2 });            
+            locationList.AddLocationListEntry(new DwarfLocationListEntry
+            {
+                Start = 0,
+                End = 0x10,
+                Expression = regExpression,
+            });
+            locationList.AddLocationListEntry(new DwarfLocationListEntry
+            {
+                Start = 0x10,
+                End = 0x20,
+                Expression = regExpression2,
+            });
+            var variable = new DwarfDIEVariable()
+            {
+                Name = "a",
+                Location = locationList,
+            };
+            dwarfFile.LocationSection.AddLocationList(locationList);
+            subProgram.AddChild(variable);
+
             var cu = new DwarfCompilationUnit()
             {
                 AddressSize = DwarfAddressSize.Bit64,

--- a/src/LibObjectFile/DiagnosticId.cs
+++ b/src/LibObjectFile/DiagnosticId.cs
@@ -110,6 +110,7 @@ namespace LibObjectFile
         DWARF_ERR_InvalidParentUnitForAddressRangeTable = 2017,
         DWARF_ERR_InvalidParentForDIE = 2018,
         DWARF_WRN_InvalidExtendedOpCodeLength = 2019,
+        DWARF_ERR_InvalidParentForLocationList = 2020,
 
     }
 }

--- a/src/LibObjectFile/Dwarf/DwarfAttribute.cs
+++ b/src/LibObjectFile/Dwarf/DwarfAttribute.cs
@@ -88,12 +88,22 @@ namespace LibObjectFile.Dwarf
 
                 if (thisSection != attrSection)
                 {
-                    diagnostics.Error(DiagnosticId.DWARF_ERR_InvalidParentForDIE, $"Invalid parent for the DIE {attrDIE} referenced by the attribute {this}. It must be within the same parent {attrSection.GetType()}.");
+                    diagnostics.Error(DiagnosticId.DWARF_ERR_InvalidParentForDIE, $"Invalid parent for the DIE {attrDIE} referenced by the attribute {this}. It must be within the same parent {thisSection.GetType()}.");
                 }
             }
             else if (ValueAsObject is DwarfExpression expr)
             {
                 expr.Verify(diagnostics);
+            }
+            else if (ValueAsObject is DwarfLocationList locationList)
+            {
+                var thisSection = this.GetParentFile();
+                var locationListSection = locationList.GetParentFile();
+
+                if (thisSection != locationListSection)
+                {
+                    diagnostics.Error(DiagnosticId.DWARF_ERR_InvalidParentForLocationList, $"Invalid parent for the LocationList {locationList} referenced by the attribute {this}. It must be within the same parent {thisSection.GetType()}.");
+                }
             }
         }
         

--- a/src/LibObjectFile/Dwarf/DwarfDIE.cs
+++ b/src/LibObjectFile/Dwarf/DwarfDIE.cs
@@ -247,7 +247,7 @@ namespace LibObjectFile.Dwarf
                     {
                         var value = cst.Value;
                         attr.ValueAsU64 = value.AsValue.U64;
-                        attr.ValueAsObject = value.AsExpression;
+                        attr.ValueAsObject = value.AsObject;
                     }
                     return;
                 }
@@ -260,7 +260,7 @@ namespace LibObjectFile.Dwarf
                 {
                     Kind = kind,
                     ValueAsU64 = value.AsValue.U64,
-                    ValueAsObject = value.AsExpression
+                    ValueAsObject = value.AsObject
                 });
             }
         }

--- a/src/LibObjectFile/Dwarf/DwarfLocation.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocation.cs
@@ -18,6 +18,12 @@ namespace LibObjectFile.Dwarf
             AsObject = expression;
         }
 
+        public DwarfLocation(DwarfLocationList locationList)
+        {
+            AsValue = default;
+            AsObject = locationList;
+        }
+
         public DwarfInteger AsValue;
 
         public object AsObject;
@@ -37,6 +43,11 @@ namespace LibObjectFile.Dwarf
         }
 
         public static implicit operator DwarfLocation(DwarfExpression value)
+        {
+            return new DwarfLocation(value);
+        }
+
+        public static implicit operator DwarfLocation(DwarfLocationList value)
         {
             return new DwarfLocation(value);
         }

--- a/src/LibObjectFile/Dwarf/DwarfLocationList.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocationList.cs
@@ -2,6 +2,7 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
+using System.Text;
 using System.Collections.Generic;
 
 namespace LibObjectFile.Dwarf
@@ -79,6 +80,28 @@ namespace LibObjectFile.Dwarf
             // End of list
             writer.WriteUInt(0);
             writer.WriteUInt(0);
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+
+            for (int i = 0; i < _locationListEntries.Count; i++)
+            {
+                if (i == 3)
+                {
+                    builder.Append(", ...");
+                    return builder.ToString();
+                }
+                else if (i != 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append(_locationListEntries[i].ToString());
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/src/LibObjectFile/Dwarf/DwarfLocationList.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocationList.cs
@@ -2,25 +2,83 @@
 // This file is licensed under the BSD-Clause 2 license.
 // See the license.txt file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace LibObjectFile.Dwarf
 {
 
-    // TODO
     public class DwarfLocationList : DwarfContainer
     {
+        private readonly List<DwarfLocationListEntry> _locationListEntries;
+
+        public DwarfLocationList()
+        {
+            _locationListEntries = new List<DwarfLocationListEntry>();
+        }
+
+        public IReadOnlyList<DwarfLocationListEntry> LocationListEntries => _locationListEntries;
+
+        public void AddLocationListEntry(DwarfLocationListEntry locationListEntry)
+        {
+            _locationListEntries.Add(this, locationListEntry);
+        }
+
+        public void RemoveLocationList(DwarfLocationListEntry locationListEntry)
+        {
+            _locationListEntries.Remove(this, locationListEntry);
+        }
+
+        public DwarfLocationListEntry RemoveLocationListEntryAt(int index)
+        {
+            return _locationListEntries.RemoveAt(this, index);
+        }
+
         protected override void UpdateLayout(DwarfLayoutContext layoutContext)
         {
-            throw new System.NotImplementedException();
+            var endOffset = Offset;
+
+            foreach (var locationListEntry in _locationListEntries)
+            {
+                locationListEntry.Offset = endOffset;
+                locationListEntry.UpdateLayoutInternal(layoutContext);
+                endOffset += locationListEntry.Size;
+            }
+
+            // End of list
+            endOffset += 2 * DwarfHelper.SizeOfUInt(layoutContext.CurrentUnit.AddressSize);
+
+            Size = endOffset - Offset;
         }
 
         protected override void Read(DwarfReader reader)
         {
-            throw new System.NotImplementedException();
+            reader.OffsetToLocationList.Add(reader.Offset, this);
+
+            while (reader.Offset < reader.Length)
+            {
+                var locationListEntry = new DwarfLocationListEntry();
+                locationListEntry.ReadInternal(reader);
+
+                if (locationListEntry.Start == 0 && locationListEntry.End == 0)
+                {
+                    // End of list
+                    return;
+                }
+
+                _locationListEntries.Add(locationListEntry);
+            }
         }
 
         protected override void Write(DwarfWriter writer)
         {
-            throw new System.NotImplementedException();
+            foreach (var locationListEntry in _locationListEntries)
+            {
+                locationListEntry.WriteInternal(writer);
+            }
+
+            // End of list
+            writer.WriteUInt(0);
+            writer.WriteUInt(0);
         }
     }
 }

--- a/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
@@ -76,5 +76,10 @@ namespace LibObjectFile.Dwarf
                 Expression.WriteInternal(writer, inLocationSection: true);
             }
         }
+
+        public override string ToString()
+        {
+            return $"Location: {Start:x} - {End:x} {Expression}";
+        }
     }
 }

--- a/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
@@ -57,8 +57,19 @@ namespace LibObjectFile.Dwarf
 
         protected override void Write(DwarfWriter writer)
         {
-            writer.WriteAddress(DwarfRelocationTarget.Code, Start);
-            writer.WriteAddress(DwarfRelocationTarget.Code, End);
+            bool isBaseAddress =
+                (writer.AddressSize == DwarfAddressSize.Bit64 && Start == ulong.MaxValue) ||
+                (writer.AddressSize == DwarfAddressSize.Bit32 && Start == uint.MaxValue);
+            if (isBaseAddress)
+            {
+                writer.WriteUInt(Start);
+                writer.WriteAddress(DwarfRelocationTarget.Code, End);
+            }
+            else
+            {
+                writer.WriteAddress(DwarfRelocationTarget.Code, Start);
+                writer.WriteAddress(DwarfRelocationTarget.Code, End);
+            }
 
             if (Expression != null)
             {

--- a/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
@@ -57,8 +57,8 @@ namespace LibObjectFile.Dwarf
 
         protected override void Write(DwarfWriter writer)
         {
-            writer.WriteUInt(Start);
-            writer.WriteUInt(End);
+            writer.WriteAddress(DwarfRelocationTarget.Code, Start);
+            writer.WriteAddress(DwarfRelocationTarget.Code, End);
 
             if (Expression != null)
             {

--- a/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocationListEntry.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+namespace LibObjectFile.Dwarf
+{
+    public class DwarfLocationListEntry : DwarfObject<DwarfLocationList>
+    {
+        public ulong Start;
+
+        public ulong End;
+
+        public DwarfExpression Expression;
+
+        public DwarfLocationListEntry()
+        {
+        }
+
+        protected override void Read(DwarfReader reader)
+        {
+            Start = reader.ReadUInt();
+            End = reader.ReadUInt();
+
+            if (Start == 0 && End == 0)
+            {
+                // End of list
+                return;
+            }
+
+            bool isBaseAddress =
+                (reader.AddressSize == DwarfAddressSize.Bit64 && Start == ulong.MaxValue) ||
+                (reader.AddressSize == DwarfAddressSize.Bit32 && Start == uint.MaxValue);
+            if (isBaseAddress)
+            {
+                // Sets new base address for following entries
+                return;
+            }
+
+            Expression = new DwarfExpression();
+            Expression.ReadInternal(reader, inLocationSection: true);
+        }
+
+        protected override void UpdateLayout(DwarfLayoutContext layoutContext)
+        {
+            var endOffset = Offset;
+
+            endOffset += 2 * DwarfHelper.SizeOfUInt(layoutContext.CurrentUnit.AddressSize);
+            if (Expression != null)
+            {
+                Expression.Offset = endOffset;
+                Expression.UpdateLayoutInternal(layoutContext, inLocationSection: true);
+                endOffset += Expression.Size;
+            }
+
+            Size = endOffset - Offset;
+        }
+
+        protected override void Write(DwarfWriter writer)
+        {
+            writer.WriteUInt(Start);
+            writer.WriteUInt(End);
+
+            if (Expression != null)
+            {
+                Expression.WriteInternal(writer, inLocationSection: true);
+            }
+        }
+    }
+}

--- a/src/LibObjectFile/Dwarf/DwarfLocationSection.cs
+++ b/src/LibObjectFile/Dwarf/DwarfLocationSection.cs
@@ -1,0 +1,89 @@
+﻿
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace LibObjectFile.Dwarf
+{
+    [DebuggerDisplay("Count = {LineTables.Count,nq}")]
+    public sealed class DwarfLocationSection : DwarfRelocatableSection
+    {
+        private readonly List<DwarfLocationList> _locationLists;
+
+        public DwarfLocationSection()
+        {
+            _locationLists = new List<DwarfLocationList>();
+        }
+
+        public IReadOnlyList<DwarfLocationList> LocationLists => _locationLists;
+
+        public void AddLocationList(DwarfLocationList locationList)
+        {
+            _locationLists.Add(this, locationList);
+        }
+
+        public void RemoveLocationList(DwarfLocationList locationList)
+        {
+            _locationLists.Remove(this, locationList);
+        }
+
+        public DwarfLocationList RemoveLineProgramTableAt(int index)
+        {
+            return _locationLists.RemoveAt(this, index);
+        }
+
+        protected override void Read(DwarfReader reader)
+        {
+            while (reader.Offset < reader.Length)
+            {
+                var locationList = new DwarfLocationList();
+                locationList.Offset = reader.Offset;
+                locationList.ReadInternal(reader);
+                AddLocationList(locationList);
+            }
+        }
+
+        public override void Verify(DiagnosticBag diagnostics)
+        {
+            base.Verify(diagnostics);
+
+            foreach (var locationList in _locationLists)
+            {
+                locationList.Verify(diagnostics);
+            }
+        }
+
+        protected override void UpdateLayout(DwarfLayoutContext layoutContext)
+        {
+            ulong sizeOf = 0;
+
+            foreach (var locationList in _locationLists)
+            {
+                locationList.Offset = Offset + sizeOf;
+                locationList.UpdateLayoutInternal(layoutContext);
+                sizeOf += locationList.Size;
+            }
+            Size = sizeOf;
+        }
+
+        protected override void Write(DwarfWriter writer)
+        {
+            var startOffset = writer.Offset;
+
+            foreach (var locationList in _locationLists)
+            {
+                locationList.WriteInternal(writer);
+            }
+
+            Debug.Assert(Size == writer.Offset - startOffset, $"Expected Size: {Size} != Written Size: {writer.Offset - startOffset}");
+        }
+
+        public override string ToString()
+        {
+            return $"Section .debug_loc, Entries: {_locationLists.Count}";
+        }
+    }
+}

--- a/src/LibObjectFile/Dwarf/DwarfOperationKindEx.cs
+++ b/src/LibObjectFile/Dwarf/DwarfOperationKindEx.cs
@@ -22,7 +22,7 @@ namespace LibObjectFile.Dwarf
 
         public override string ToString()
         {
-            return ToStringInternal() ?? $"Unknown {nameof(DwarfOperationKindEx)} (0x{Value:x2})";
+            return ToStringInternal() ?? $"Unknown {nameof(DwarfOperationKindEx)} ({(uint)Value:x2})";
         }
 
         public bool Equals(DwarfOperationKindEx other)

--- a/src/LibObjectFile/Dwarf/DwarfReader.cs
+++ b/src/LibObjectFile/Dwarf/DwarfReader.cs
@@ -26,6 +26,7 @@ namespace LibObjectFile.Dwarf
             _unresolvedDIECompilationUnitReference = new List<DwarfDIEReference>();
             _attributesWithUnresolvedDIESectionReference = new List<DwarfDIEReference>();
             OffsetToLineProgramTable = new Dictionary<ulong, DwarfLineProgramTable>();
+            OffsetToLocationList = new Dictionary<ulong, DwarfLocationList>();
             _stack = new Stack<DwarfDIE>();
             _stackWithLineProgramTable = new Stack<DwarfDIE>();
         }
@@ -43,7 +44,9 @@ namespace LibObjectFile.Dwarf
         internal DwarfAttributeDescriptor CurrentAttributeDescriptor { get; set; }
 
         internal Dictionary<ulong, DwarfLineProgramTable> OffsetToLineProgramTable { get; }
-        
+
+        internal Dictionary<ulong, DwarfLocationList> OffsetToLocationList { get; }
+
         internal void PushDIE(DwarfDIE die)
         {
             _registeredDIEPerCompilationUnit.Add(die.Offset - CurrentUnit.Offset, die);

--- a/src/LibObjectFile/Dwarf/DwarfReaderContext.cs
+++ b/src/LibObjectFile/Dwarf/DwarfReaderContext.cs
@@ -22,6 +22,7 @@ namespace LibObjectFile.Dwarf
             DebugAbbrevStream = elfContext.AbbreviationTable?.Stream;
             DebugInfoStream = elfContext.InfoSection?.Stream;
             DebugAddressRangeStream = elfContext.AddressRangeTable?.Stream;
+            DebugLocationStream = elfContext.LocationSection?.Stream;
         }
 
         public bool IsInputReadOnly { get; set; }

--- a/src/LibObjectFile/Dwarf/DwarfReaderWriterContext.cs
+++ b/src/LibObjectFile/Dwarf/DwarfReaderWriterContext.cs
@@ -23,5 +23,7 @@ namespace LibObjectFile.Dwarf
         public TextWriter DebugLinePrinter { get; set; }
 
         public Stream DebugInfoStream { get; set; }
+
+        public Stream DebugLocationStream { get; set; }
     }
 }


### PR DESCRIPTION
One of my experiments uses the LibObjectFile library to generate DWARF debugging info for the .NET NativeAOT compiler. I am missing support for the location list when emitting information about variable locations. Here's a minimal viable implementation to add such support. It's missing error handling at the moment but I am posting it for some early review to get feedback on the general API shape.