### PR TITLE
Add support for building optimized string table

### DIFF
--- a/src/LibObjectFile/Elf/Sections/ElfSymbolTable.cs
+++ b/src/LibObjectFile/Elf/Sections/ElfSymbolTable.cs
@@ -227,7 +227,7 @@ namespace LibObjectFile.Elf
                     diagnostics.Error(DiagnosticId.ELF_ERR_InvalidSymbolEntrySectionParent, $"Invalid section for the symbol entry #{i} in the {nameof(ElfSymbolTable)} section [{Index}]. The section of the entry `{entry}` must the same than this symbol table section");
                 }
 
-                stringTable.GetOrCreateIndex(entry.Name);
+                stringTable.ReserveString(entry.Name);
 
                 // Update the last local index
                 if (entry.Bind == ElfSymbolBind.Local)


### PR DESCRIPTION
The current implementation of `ElfStringTable` doesn't scale well in terms of time and memory usage. This was discovered in the experiment which uses LibObjectFile as ELF emitting backend for the .NET NativeAOT. [Link to the discussion thread.](https://github.com/dotnet/runtime/pull/92705#issuecomment-1742126727)

The root cause of the issue is the [optimization](https://github.com/xoofx/LibObjectFile/blob/dcf2ac5bd79953a54ad1fb8c1ca3627616bdf58f/src/LibObjectFile/Elf/Sections/ElfStringTable.cs#L109-L121) that tries to deduplicate strings that share the same suffix. This optimization creates enormous amount of strings on the managed heap, creates a dictionary with large amount of collisions, and produces only marginally better output for the common cases. It doesn't produce the optimal solution either since it depends on the order of the strings.

I created a [benchmark](https://github.com/filipnavara/StringTableBenchmark) to see how bad the problem is and what can be done to improve the situation. The benchmark implements two strategies (`MultiKeySort` and `Naive`) in addition to the current `ElfStringTable` implementation used for reference. The `MultiKeySort` algorithm produces the optimal solution by pre-sorting the input, the `Naive` algorithm does no suffix deduplication.

Results on my Ryzen 7950X machine:
| Method         | Mean       | Error     | StdDev    | Gen0       | Gen1       | Gen2      | Allocated |
|--------------- |-----------:|----------:|----------:|-----------:|-----------:|----------:|----------:|
| ElfStringTable | 320.920 ms | 6.2597 ms | 8.5684 ms | 14000.0000 | 13500.0000 | 4000.0000 | 316.79 MB |
| MultiKeySort   |   5.782 ms | 0.0296 ms | 0.0263 ms |   796.8750 |   789.0625 |  789.0625 |   4.86 MB |
| Naive          |   1.912 ms | 0.0274 ms | 0.0256 ms |   955.0781 |   945.3125 |  945.3125 |   5.81 MB |

The `MultiKeySort` algorithm produces an output that is 23% smaller than the `Naive` implementation for the sample data. Notably, `MultiKeySort` is more than 50 times faster than the current implementation and uses 65 times less memory in the process.

`ElfStringTable` offers an API that can build the string table incrementally, but the most common case is when it's populated from the symbol table. I present a solution where the symbol table case uses the `MultiKeySort` algorithm by introducing a new `ElfStringTable.ReserveString` method and then builds the optimal solution lazily when the string table is emitted or indexed. The existing ` GetOrCreateIndex` method is modified to use the naive implementation and removes the suffix optimization.

