### PR TITLE
Add support for more than SHN_LORESERVE sections

### DIFF
--- a/src/LibObjectFile.Tests/Elf/ElfSimpleTests.cs
+++ b/src/LibObjectFile.Tests/Elf/ElfSimpleTests.cs
@@ -448,11 +448,6 @@ namespace LibObjectFile.Tests.Elf
             diagnostics = elf.Verify();
             Assert.False(diagnostics.HasErrors);
 
-            for (int i = 0; i < ushort.MaxValue; i++)
-            {
-
-            }
-
             uint visibleSectionCount = elf.VisibleSectionCount;
 
             using (var outStream = File.OpenWrite("manysections"))

--- a/src/LibObjectFile.Tests/Elf/ElfSimpleTests.cs
+++ b/src/LibObjectFile.Tests/Elf/ElfSimpleTests.cs
@@ -470,6 +470,13 @@ namespace LibObjectFile.Tests.Elf
                 Assert.True(elf.Sections[i + 2] is ElfBinarySection);
                 Assert.AreEqual($".section{i}", elf.Sections[i + 2].Name.Value);
             }
+
+            Assert.True(elf.Sections[ushort.MaxValue + 3] is ElfSymbolTable);
+            symbolTable = (ElfSymbolTable)elf.Sections[ushort.MaxValue + 3];
+            for (int i = 0; i < ushort.MaxValue; i++)
+            {
+                Assert.AreEqual($".section{i}", symbolTable.Entries[i + 1].Section.Section.Name.Value);
+            }
         }
     }
 }

--- a/src/LibObjectFile.Tests/Elf/ElfSimpleTests.cs
+++ b/src/LibObjectFile.Tests/Elf/ElfSimpleTests.cs
@@ -450,6 +450,14 @@ namespace LibObjectFile.Tests.Elf
             }
 
             Assert.AreEqual(visibleSectionCount, elf.VisibleSectionCount);
+            Assert.True(elf.Sections[0] is ElfNullSection);
+            Assert.True(elf.Sections[1] is ElfProgramHeaderTable);
+
+            for (int i = 0; i < ushort.MaxValue; i++)
+            {
+                Assert.True(elf.Sections[i + 2] is ElfBinarySection);
+                Assert.AreEqual($".section{i}", elf.Sections[i + 2].Name.Value);
+            }
         }
     }
 }

--- a/src/LibObjectFile/DiagnosticId.cs
+++ b/src/LibObjectFile/DiagnosticId.cs
@@ -69,6 +69,8 @@ namespace LibObjectFile
         ELF_ERR_InvalidStreamForSectionNoBits = 156,
         ELF_ERR_InvalidNullSection = 157,
         ELF_ERR_InvalidAlignmentOutOfRange = 158,
+        ELF_ERR_MissingSectionHeaderIndices = 159,
+        ELF_ERR_MissingNullSection = 159,
 
         AR_ERR_InvalidMagicLength = 1000,
         AR_ERR_MagicNotFound = 1001,

--- a/src/LibObjectFile/Elf/ElfObjectFile.cs
+++ b/src/LibObjectFile/Elf/ElfObjectFile.cs
@@ -179,6 +179,12 @@ namespace LibObjectFile.Elf
                 diagnostics.Error(DiagnosticId.ELF_ERR_InvalidHeaderFileClassNone, $"Cannot compute the layout with an {nameof(ElfObjectFile)} having a {nameof(FileClass)} == {ElfFileClass.None}");
             }
 
+            if (VisibleSectionCount >= ElfNative.SHN_LORESERVE &&
+                Sections[0] is not ElfNullSection)
+            {
+                diagnostics.Error(DiagnosticId.ELF_ERR_MissingNullSection, $"Section count is higher than SHN_LORESERVE ({ElfNative.SHN_LORESERVE}) but the first section is not a NULL section");                
+            }
+
             foreach (var segment in Segments)
             {
                 segment.Verify(diagnostics);

--- a/src/LibObjectFile/Elf/ElfReader{TDecoder}.cs
+++ b/src/LibObjectFile/Elf/ElfReader{TDecoder}.cs
@@ -385,7 +385,7 @@ namespace LibObjectFile.Elf
             if (errorMessageFormat == null) throw new ArgumentNullException(nameof(errorMessageFormat));
 
             // Connect section Link instance
-            if (!link.IsSpecial)
+            if (!link.IsEmpty)
             {
                 if (link.SpecialIndex == _sectionStringTableIndex)
                 {
@@ -396,13 +396,21 @@ namespace LibObjectFile.Elf
                     var sectionIndex = link.SpecialIndex;
 
                     bool sectionFound = false;
-                    foreach (var section in ObjectFile.Sections)
+                    if (sectionIndex < ObjectFile.Sections.Count && ObjectFile.Sections[(int)sectionIndex].SectionIndex == sectionIndex)
                     {
-                        if (section.SectionIndex == sectionIndex)
+                        link = new ElfSectionLink(ObjectFile.Sections[(int)sectionIndex]);
+                        sectionFound = true;
+                    }
+                    else
+                    {
+                        foreach (var section in ObjectFile.Sections)
                         {
-                            link = new ElfSectionLink(section);
-                            sectionFound = true;
-                            break;
+                            if (section.SectionIndex == sectionIndex)
+                            {
+                                link = new ElfSectionLink(section);
+                                sectionFound = true;
+                                break;
+                            }
                         }
                     }
 
@@ -722,6 +730,9 @@ namespace LibObjectFile.Elf
                     break;
                 case ElfSectionType.Note:
                     section = new ElfNoteTable();
+                    break;
+                case ElfSectionType.SymbolTableSectionHeaderIndices:
+                    section = new ElfSymbolTableSectionHeaderIndices();
                     break;
             }
 

--- a/src/LibObjectFile/Elf/Sections/ElfBinarySection.cs
+++ b/src/LibObjectFile/Elf/Sections/ElfBinarySection.cs
@@ -42,7 +42,7 @@ namespace LibObjectFile.Elf
         }
 
         public override ulong TableEntrySize => OriginalTableEntrySize;
-        
+
         /// <summary>
         /// Gets or sets the associated stream to this section.
         /// </summary>

--- a/src/LibObjectFile/Elf/Sections/ElfSymbolTableSectionHeaderIndices.cs
+++ b/src/LibObjectFile/Elf/Sections/ElfSymbolTableSectionHeaderIndices.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection.PortableExecutable;
 
 namespace LibObjectFile.Elf
 {

--- a/src/LibObjectFile/Elf/Sections/ElfSymbolTableSectionHeaderIndices.cs
+++ b/src/LibObjectFile/Elf/Sections/ElfSymbolTableSectionHeaderIndices.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// This file is licensed under the BSD-Clause 2 license.
+// See the license.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace LibObjectFile.Elf
+{
+    /// <summary>
+    /// A section with the type <see cref="ElfSectionType.SymbolTableSectionHeaderIndices"/>
+    /// </summary>
+    public sealed class ElfSymbolTableSectionHeaderIndices : ElfSection
+    {
+        public const string DefaultName = ".symtab_shndx";
+
+        private readonly List<ElfSectionLink> _entries;
+
+        public ElfSymbolTableSectionHeaderIndices() : base(ElfSectionType.SymbolTableSectionHeaderIndices)
+        {
+            Name = DefaultName;
+            _entries = new List<ElfSectionLink>();
+        }
+
+        public override ElfSectionType Type
+        {
+            get => base.Type;
+            set
+            {
+                if (value != ElfSectionType.SymbolTableSectionHeaderIndices)
+                {
+                    throw new ArgumentException($"Invalid type `{Type}` of the section [{Index}] `{nameof(ElfSymbolTableSectionHeaderIndices)}`. Only `{ElfSectionType.SymbolTableSectionHeaderIndices}` is valid");
+                }
+                base.Type = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets a list of <see cref="ElfSectionLink"/> entries.
+        /// </summary>
+        public IReadOnlyList<ElfSectionLink> Entries => _entries;
+
+        public override unsafe ulong TableEntrySize => sizeof(uint);
+
+        protected override void Read(ElfReader reader)
+        {
+            var numberOfEntries = base.Size / TableEntrySize;
+            _entries.Clear();
+            _entries.Capacity = (int)numberOfEntries;
+            for (ulong i = 0; i < numberOfEntries; i++)
+            {
+                _entries.Add(new ElfSectionLink(reader.ReadU32()));
+            }
+        }
+
+        protected override void Write(ElfWriter writer)
+        {
+            // Write all entries
+            for (int i = 0; i < Entries.Count; i++)
+            {
+                writer.WriteU32(Entries[i].GetIndex());
+            }
+        }
+
+        protected override void AfterRead(ElfReader reader)
+        {
+            // Verify that the link is safe and configured as expected
+            Link.TryGetSectionSafe<ElfSymbolTable>(nameof(ElfSymbolTableSectionHeaderIndices), nameof(Link), this, reader.Diagnostics, out var symbolTable, ElfSectionType.SymbolTable, ElfSectionType.DynamicLinkerSymbolTable);
+
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                var entry = _entries[i];
+                if (entry.SpecialIndex != 0)
+                {
+                    entry = reader.ResolveLink(entry.Section, $"Invalid link section index {entry.SpecialIndex} for symbol table entry [{i}] from symbol table section [{this}]");
+                    _entries[i] = entry;
+
+                    // Update the link in symbol table
+                    var symbolTableEntry = symbolTable.Entries[i];
+                    symbolTableEntry.Section = entry.Section;
+                    symbolTable.Entries[i] = symbolTableEntry;
+                }
+            }
+        }
+
+        public override void Verify(DiagnosticBag diagnostics)
+        {
+            base.Verify(diagnostics);
+
+            // Verify that the link is safe and configured as expected
+            if (!Link.TryGetSectionSafe<ElfSymbolTable>(nameof(ElfSymbolTableSectionHeaderIndices), nameof(Link), this, diagnostics, out var symbolTable, ElfSectionType.SymbolTable, ElfSectionType.DynamicLinkerSymbolTable))
+            {
+                return;
+            }
+
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                var entry = _entries[i];
+                if (entry.SpecialIndex != 0 && entry.Section != null && entry.Section.Parent != Parent)
+                {
+                    diagnostics.Error(DiagnosticId.ELF_ERR_InvalidSymbolEntrySectionParent, $"Invalid section for the symbol entry #{i} in the {nameof(ElfSymbolTable)} section [{Index}]");
+                }
+            }
+        }
+
+        public override unsafe void UpdateLayout(DiagnosticBag diagnostics)
+        {
+            if (diagnostics == null) throw new ArgumentNullException(nameof(diagnostics));
+            Size = Parent == null || Parent.FileClass == ElfFileClass.None ? 0 : (ulong)Entries.Count * sizeof(uint);
+        }
+    }
+}


### PR DESCRIPTION
ELF files with more than SHN_LORESERVE (0xff00) sections need special handling for the number of sections and link to section header string table. Both of these fields are unrepresentable using the `ushort` fields in the ELF header and they are instead written in fields of the NULL section.

---

> If the number of sections is greater than or equal to SHN_LORESERVE (0xff00), e_shnum has the value SHN_UNDEF (0) and the actual number of section header table entries is contained in the sh_size field of the section header at index 0 (otherwise, the sh_size member of the initial entry contains 0).

---

> e_shstrndx
>
> This member holds the section header table index of the entry associated with the section name string table.  If the file has no section name string table, this member holds the value SHN_UNDEF.
>
> If the index of section name string table section is larger than or equal to SHN_LORESERVE (0xff00), this member holds SHN_XINDEX (0xffff) and the real index of the section name string table section is held in the sh_link member of the initial entry in section header table. Otherwise, the sh_link member of the initial entry in section header table contains the value zero.